### PR TITLE
Support for activerecord-mysql-awesome

### DIFF
--- a/lib/connection_adapters/mysql2.rb
+++ b/lib/connection_adapters/mysql2.rb
@@ -2,7 +2,7 @@ require 'active_record/connection_adapters/mysql2_adapter'
 
 module ActiveRecord
   module ConnectionAdapters
-    existing_class = defined?( Mysql2Adapter ) ? Mysql2Adapter : AbstractMysqlAdapter
+    existing_class = ActiveRecord::VERSION::MAJOR < 4 && defined?( Mysql2Adapter ) ? Mysql2Adapter : AbstractMysqlAdapter
 
     existing_class.class_eval do
       def native_database_types_with_enum


### PR DESCRIPTION
I tried to use activerecord-mysql-awesome and activerecord_enum in the same project and ended up
getting this error after running _rake db:migrate_

type_to_sql_with_enum'
/Users/chris/src/mms/lib/tasks/app.rake:66:in

This commit should fix this issue
